### PR TITLE
Added flag for movie generation

### DIFF
--- a/TrajectoryNet/main.py
+++ b/TrajectoryNet/main.py
@@ -401,30 +401,32 @@ def plot_output(device, args, model):
         end_times=args.int_tps,
         ntimes=100,
     )
-    save_trajectory(
-        args.data.base_density(),
-        args.data.base_sample(),
-        model,
-        data_samples,
-        save_traj_dir,
-        device=device,
-        end_times=args.int_tps,
-        ntimes=25,
-    )
-    trajectory_to_video(save_traj_dir)
+    
+    if args.save_movie:
+        save_trajectory(
+            args.data.base_density(),
+            args.data.base_sample(),
+            model,
+            data_samples,
+            save_traj_dir,
+            device=device,
+            end_times=args.int_tps,
+            ntimes=25,
+        )
+        trajectory_to_video(save_traj_dir)
 
-    density_dir = os.path.join(args.save, "density2")
-    save_trajectory_density(
-        args.data.base_density(),
-        model,
-        data_samples,
-        density_dir,
-        device=device,
-        end_times=args.int_tps,
-        ntimes=25,
-        memory=0.1,
-    )
-    trajectory_to_video(density_dir)
+        density_dir = os.path.join(args.save, "density2")
+        save_trajectory_density(
+            args.data.base_density(),
+            model,
+            data_samples,
+            density_dir,
+            device=device,
+            end_times=args.int_tps,
+            ntimes=25,
+            memory=0.1,
+        )
+        trajectory_to_video(density_dir)
 
 
 def main(args):

--- a/TrajectoryNet/main.py
+++ b/TrajectoryNet/main.py
@@ -402,30 +402,31 @@ def plot_output(device, args, model):
         ntimes=100,
     )
     
+    save_trajectory(
+        args.data.base_density(),
+        args.data.base_sample(),
+        model,
+        data_samples,
+        save_traj_dir,
+        device=device,
+        end_times=args.int_tps,
+        ntimes=25,
+    )
+    
+    density_dir = os.path.join(args.save, "density2")
+    save_trajectory_density(
+        args.data.base_density(),
+        model,
+        data_samples,
+        density_dir,
+        device=device,
+        end_times=args.int_tps,
+        ntimes=25,
+        memory=0.1,
+    )
+    
     if args.save_movie:
-        save_trajectory(
-            args.data.base_density(),
-            args.data.base_sample(),
-            model,
-            data_samples,
-            save_traj_dir,
-            device=device,
-            end_times=args.int_tps,
-            ntimes=25,
-        )
         trajectory_to_video(save_traj_dir)
-
-        density_dir = os.path.join(args.save, "density2")
-        save_trajectory_density(
-            args.data.base_density(),
-            model,
-            data_samples,
-            density_dir,
-            device=device,
-            end_times=args.int_tps,
-            ntimes=25,
-            memory=0.1,
-        )
         trajectory_to_video(density_dir)
 
 

--- a/TrajectoryNet/parse.py
+++ b/TrajectoryNet/parse.py
@@ -116,3 +116,4 @@ parser.add_argument(
     help="choose embedding name to perform TrajectoryNet on",
 )
 parser.add_argument("--whiten", action="store_true", help="Whiten data before running TrajectoryNet")
+parser.add_argument("--save_movie", action="store_false", help="Construct trajectory movie, requires ffmpeg to be installed")


### PR DESCRIPTION
I ran TrajectoryNet overnight and it failed because of a non-python dependency which I had missed `ffmpeg`. This is needed to generated a trajectory movie from the images, whicH I did not require.

So I added a CLI flag `--save_movie` to specify not needing this behavior. For now, this defaults to `true` (it generates the movie). If we can add a warning for the linux dependency somewhere in the code too that would be good, but this is my rough solution.